### PR TITLE
Add /api/tips/stats endpoint with topic statistics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
       },
       "devDependencies": {
         "chai": "^5.1.1",
-        "chai-http": "^5.0.0",
         "eslint": "^8.56.0",
         "mocha": "^10.4.0",
         "nodemon": "^3.0.2",
@@ -187,43 +186,6 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
-      }
-    },
-    "node_modules/@types/cookiejar": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
-      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/methods": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
-      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
-      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/@types/superagent": {
-      "version": "8.1.9",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
-      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/cookiejar": "^2.1.5",
-        "@types/methods": "^1.1.4",
-        "@types/node": "*",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -559,25 +521,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/chai-http": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-5.1.2.tgz",
-      "integrity": "sha512-UFup7mUGkkjmi9bGA7F6vfp3lzGQZjtL//CEd+a4C+vlynSv756XHDUK8PoYk/UpTBBXqSghjQaJOUMUxJXNaA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/superagent": "^8.1.7",
-        "charset": "^1.0.1",
-        "cookiejar": "^2.1.4",
-        "is-ip": "^5.0.1",
-        "methods": "^1.1.2",
-        "qs": "^6.12.1",
-        "superagent": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -593,16 +536,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/charset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz",
-      "integrity": "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/check-error": {
@@ -663,22 +596,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/clone-regexp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
-      "integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-regexp": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/color-convert": {
@@ -750,19 +667,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/convert-hrtime": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
-      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cookie": {
@@ -1500,19 +1404,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/function-timeout": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz",
-      "integrity": "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1815,19 +1706,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1883,23 +1761,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-ip": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.1.tgz",
-      "integrity": "sha512-FCsGHdlrOnZQcp0+XT5a+pYowf33itBalCl+7ovNXC/7o5BhIpG14M3OrpPPdBSIQJCm+0M5+9mO7S9VVTTCFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-regex": "^5.0.0",
-        "super-regex": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1928,19 +1789,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-regexp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
-      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -3019,24 +2867,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/super-regex": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
-      "integrity": "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone-regexp": "^3.0.0",
-        "function-timeout": "^0.1.0",
-        "time-span": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -3116,22 +2946,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/time-span": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
-      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "convert-hrtime": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3207,13 +3021,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/src/controllers/tipController.js
+++ b/src/controllers/tipController.js
@@ -75,6 +75,22 @@ export const getByTopic = async (req, res, next) => {
 };
 
 /**
+ * Get tip statistics
+ */
+export const getStats = async (req, res, next) => {
+  try {
+    console.log('📊 Fetching tip statistics...');
+    const stats = await tipService.getStats();
+    console.log('✅ Tip statistics fetched successfully');
+    res.json(stats);
+  } catch (error) {
+    console.log('❌ Error fetching tip statistics:', error.message);
+    next(error);
+  }
+};
+
+
+/**
  * Create a new tip
  */
 export const create = async (req, res, next) => {

--- a/src/routes/tips.js
+++ b/src/routes/tips.js
@@ -10,6 +10,7 @@ const router = express.Router();
 // GET routes (primary focus for the course)
 router.get('/', tipController.getAll);
 router.get('/random', tipController.getRandom);
+router.get('/stats', tipController.getStats);
 router.get('/topic/:topic', tipController.getByTopic);
 router.get('/:id', tipController.getById);
 

--- a/src/services/tipService.js
+++ b/src/services/tipService.js
@@ -25,6 +25,16 @@ async function readTips() {
   }
 }
 
+async function readTipsFile() {
+  try {
+    const data = await readFile(DATA_FILE, 'utf8');
+    return JSON.parse(data);
+  } catch (error) {
+    console.log('⚠️ Could not read full tips file, returning empty data');
+    return { tips: [], metadata: { topics: [] } };
+  }
+}
+
 /**
  * Write tips to JSON file
  */
@@ -113,4 +123,32 @@ export const remove = async (id) => {
   tips.splice(index, 1);
   await writeTips(tips);
   return true;
+};
+
+/**
+ * Get tip statistics grouped by topic
+ */
+export const getStats = async () => {
+  const fileData = await readTipsFile();
+  const tips = fileData.tips || [];
+  const topics = fileData.metadata?.topics || [];
+
+  const byTopic = {};
+  const total = tips.length;
+
+  for (const topic of topics) {
+    byTopic[topic] = 0;
+  }
+
+  for (const tip of tips) {
+    const topic = tip.topic?.toLowerCase();
+    if (topic && byTopic.hasOwnProperty(topic)) {
+      byTopic[topic]++;
+    }
+  }
+
+  return {
+    total,
+    byTopic
+  };
 };


### PR DESCRIPTION
### Description
This PR adds a new `GET /api/tips/stats` endpoint that returns tip statistics grouped by topic.
Fixes #5 
### Changes
- Added a stats service to aggregate tips by topic
- Included total tip count in the response
- Ensured all topics are returned, even when count is zero
- Exposed stats via a new API endpoint

### Why
This enables dashboard-friendly analytics without duplicating logic on the client.
